### PR TITLE
CTC-646: Reflect breaking changes in the .NET SDK

### DIFF
--- a/net/delivery-api/GetElement.cs
+++ b/net/delivery-api/GetElement.cs
@@ -8,5 +8,6 @@ IDeliveryClient client = DeliveryClientBuilder
       .Build();
 
 // Gets the model of specific element within a specific content type
-ContentElement element = await client.GetContentElementAsync("coffee", "processing");
+DeliveryElementResponse response = await client.GetContentElementAsync("coffee", "processing");
+ContentElement element = response.Element;
 // EndDocSection

--- a/net/delivery-api/GetItemPreview.cs
+++ b/net/delivery-api/GetItemPreview.cs
@@ -11,7 +11,6 @@ IDeliveryClient client = DeliveryClientBuilder
     .Build();
 
 // Generate strongly typed models via https://github.com/Kentico/cloud-generators-net
-DeliveryItemResponse<object> response = await client.GetItemAsync<object>("on_roasts");
-
-var items = response.Items;
+DeliveryItemResponse response = await client.GetItemAsync("on_roasts");
+ContentItem item = response.Item;
 // EndDocSection

--- a/net/delivery-api/GetItems.cs
+++ b/net/delivery-api/GetItems.cs
@@ -15,5 +15,5 @@ DeliveryItemListingResponse<Article> response = await client.GetItemsAsync<Artic
     new OrderParameter("elements.post_date", SortOrder.Descending)
     );
 
-var items = response.Items;
+IReadOnlyList<ContentItem> items = response.Items;
 // EndDocSection

--- a/net/delivery-api/GetTaxonomyGroup.cs
+++ b/net/delivery-api/GetTaxonomyGroup.cs
@@ -8,5 +8,6 @@ IDeliveryClient client = DeliveryClientBuilder
       .Build();
 
 // Gets a specific taxonomy group
-TaxonomyGroup taxonomyGroup = await client.GetTaxonomyAsync("personas");
+DeliveryTaxonomyResponse response = await client.GetTaxonomyAsync("personas");
+TaxonomyGroup taxonomy = response.Taxonomy;
 // EndDocSection

--- a/net/delivery-api/GetTaxonomyGroups.cs
+++ b/net/delivery-api/GetTaxonomyGroups.cs
@@ -8,9 +8,9 @@ IDeliveryClient client = DeliveryClientBuilder
       .Build();
 
 // Gets 3 taxonomy groups
-DeliveryTypeListingResponse response = await client.GetTaxonomiesAsync(
+DeliveryTaxonomyListingResponse response = await client.GetTaxonomiesAsync(
     new LimitParameter(3)
     );
 
-var taxonomyGroups = response.Taxonomy;
+IReadOnlyList<TaxonomyGroup> taxonomies = response.Taxonomies;
 // EndDocSection

--- a/net/delivery-api/GetType.cs
+++ b/net/delivery-api/GetType.cs
@@ -8,5 +8,6 @@ IDeliveryClient client = DeliveryClientBuilder
       .Build();
 
 // Gets a specific content type
-ContentType type = await client.GetTypeAsync("coffee");
+DeliveryTypeResponse response = await client.GetTypeAsync("coffee");
+ContentType type = response.Type;
 // EndDocSection

--- a/net/delivery-api/GetTypes.cs
+++ b/net/delivery-api/GetTypes.cs
@@ -12,5 +12,5 @@ DeliveryTypeListingResponse response = await client.GetTypesAsync(
     new LimitParameter(3)
     );
 
-var types = response.Types;
+IReadOnlyList<ContentType> types = response.Types;
 // EndDocSection


### PR DESCRIPTION
### Motivation

Update .NET code samples to reflect breaking changes in the .NET SDK 11.0.0 and also fix some errors. Please note that the .NET SDK 11.0.0 has not been released yet, only 11.0.0-beta1. This pull requests should be merged and documentation updated after the .NET SDK 11.0.0 has been released.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

I tested all the .NET code samples. If you would like to test them as well, create a console application, add the .NET SDK 11.0.0-beta1 and run all the .NET code samples. You will need a Preview API access key.